### PR TITLE
Fix CRUD table first-row selection

### DIFF
--- a/src/lib/CRUD/CrudTable.svelte
+++ b/src/lib/CRUD/CrudTable.svelte
@@ -20,7 +20,6 @@
     let selectedRowId: string | number | null = null;
 
     function handleRowClick(id: string | number) {
-        if (id === 0) return;
         selectedRowId = selectedRowId === id ? null : id;
         dispatch("rowClick", { id: selectedRowId });
     }


### PR DESCRIPTION
## Summary
- allow selecting the first row in `<CrudTable>`

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684243c7c1d8832081b946d0c03aa6f9