### PR TITLE
Add code preview with copy button to CRUD example

### DIFF
--- a/src/routes/crud/+page.svelte
+++ b/src/routes/crud/+page.svelte
@@ -190,6 +190,22 @@
     onMount(async () => {
         await enlistar();
     });
+
+    const codePreview = `<CrudWrapper
+    {todosLosObjetos}
+    {tableH}
+    {totalRows}
+    bind:Filtros
+    bind:PageSize
+    bind:currentPage
+    bind:selectedAscOrDesc
+    bind:selectedSort
+    {loading}
+    showAddButton={true}
+    showImportButton={false}
+    onFilter={enlistar}
+    onAdd={handleAdd}
+/>`;
 </script>
 
 <svelte:head>
@@ -212,4 +228,18 @@
     onFilter={enlistar}
     onAdd={handleAdd}
 />
+    <div class="bg-white p-6 rounded-lg shadow-md mt-6">
+        <div class="flex justify-between items-center mb-4">
+            <h2 class="text-xl font-semibold">Code Preview</h2>
+            <button
+                class="text-emerald-500 hover:text-emerald-600 text-sm font-medium"
+                on:click={() => {
+                    navigator.clipboard.writeText(codePreview);
+                }}
+            >
+                Copy Code
+            </button>
+        </div>
+        <pre class="bg-gray-800 text-gray-100 p-4 rounded-md overflow-x-auto text-sm"><code>{codePreview}</code></pre>
+    </div>
 </div>


### PR DESCRIPTION
## Summary
- add a `codePreview` snippet string in CRUD example
- display the snippet below the CRUD component with a copy button

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684244e296e08320b9fbe4ae197daaaf