### PR TITLE
Replace Tailwind with custom CSS classes

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,1 +1,299 @@
-@import "tailwindcss";
+/* Root layout */
+.layout-container {
+    min-height: 100vh;
+    background: #f3f4f6; /* gray-100 */
+}
+
+/* Navigation */
+.navbar {
+    background: #ffffff;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.navbar-inner {
+    max-width: 80rem; /* max-w-7xl */
+    margin: 0 auto;
+    padding-left: 1rem; /* px-4 */
+    padding-right: 1rem;
+}
+
+@media (min-width: 640px) {
+    .navbar-inner {
+        padding-left: 1.5rem; /* sm:px-6 */
+        padding-right: 1.5rem;
+    }
+}
+
+@media (min-width: 1024px) {
+    .navbar-inner {
+        padding-left: 2rem; /* lg:px-8 */
+        padding-right: 2rem;
+    }
+}
+
+.navbar-brand {
+    font-size: 1.25rem;
+    font-weight: bold;
+    color: #1f2937;
+    text-decoration: none;
+    transition: color 0.15s ease;
+}
+
+.navbar-brand:hover {
+    color: #374151;
+}
+
+.nav-links {
+    display: flex;
+    gap: 2rem;
+    margin-left: 1.5rem;
+}
+
+.navbar-main {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 4rem; /* h-16 */
+}
+
+.brand-wrapper {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.links-desktop {
+    display: none;
+    margin-left: 0;
+    gap: 2rem;
+}
+
+@media (min-width: 640px) {
+    .links-desktop {
+        display: flex;
+        margin-left: 1.5rem; /* sm:ml-6 */
+    }
+    .mobile-menu {
+        display: none;
+    }
+}
+
+.nav-link {
+    display: inline-flex;
+    align-items: center;
+    padding-left: 0.25rem; /* px-1 */
+    padding-right: 0.25rem;
+    padding-top: 0.25rem; /* pt-1 */
+    padding-bottom: 0;
+    border-bottom: 2px solid transparent;
+    color: #6b7280; /* text-gray-500 */
+    font-size: 0.875rem; /* text-sm */
+    font-weight: 500; /* font-medium */
+    text-decoration: none;
+    transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.nav-link:hover {
+    border-color: #d1d5db;
+    color: #374151;
+}
+
+.nav-link.active {
+    border-color: #3b82f6;
+    color: #111827;
+}
+
+.mobile-menu {
+    padding-top: 0.5rem; /* pt-2 */
+    padding-bottom: 0.75rem; /* pb-3 */
+}
+
+.mobile-menu > div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem; /* space-y-1 */
+}
+
+.mobile-link {
+    display: block;
+    padding-top: 0.5rem; /* py-2 */
+    padding-bottom: 0.5rem;
+    padding-left: 0.75rem; /* pl-3 */
+    padding-right: 1rem; /* pr-4 */
+    border-left: 4px solid transparent;
+    font-size: 1rem;
+    font-weight: 500;
+    color: #6b7280;
+    text-decoration: none;
+    transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.mobile-link:hover {
+    background: #f9fafb;
+    border-color: #d1d5db;
+    color: #374151;
+}
+
+.mobile-link.active {
+    background: #eff6ff;
+    border-color: #3b82f6;
+    color: #1e40af;
+}
+
+/* Modal */
+.modal {
+    position: fixed;
+    inset: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 50;
+    outline: none;
+}
+
+.modal-content {
+    background: #ffffff;
+    box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    border: 0;
+    outline: none;
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 1rem;
+    border-bottom: 1px solid #e2e8f0; /* blueGray-200 */
+    border-top-left-radius: 0.25rem;
+    border-top-right-radius: 0.25rem;
+}
+
+.modal-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.close-btn {
+    margin-left: auto;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-size: 1.5rem;
+}
+
+.modal-body {
+    padding: 0.5rem;
+    flex: 1;
+    position: relative;
+}
+
+@media (min-width: 640px) {
+    .modal-body {
+        padding: 1rem; /* sm:p-4 */
+    }
+}
+
+.modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 0.75rem;
+    border-top: 1px solid #e2e8f0; /* blueGray-200 */
+}
+
+.btn-save {
+    background: #10b981;
+    color: #ffffff;
+    font-weight: bold;
+    text-transform: uppercase;
+    font-size: 0.875rem;
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.25rem;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    cursor: pointer;
+    transition: box-shadow 0.15s ease, background-color 0.15s ease;
+}
+
+.btn-save:hover {
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.btn-save:active {
+    background: #059669;
+}
+
+.btn-save:disabled {
+    background: #6ee7b7;
+    cursor: default;
+}
+
+.btn-cancel {
+    color: #ef4444;
+    font-weight: bold;
+    text-transform: uppercase;
+    font-size: 0.875rem;
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.25rem;
+    margin-left: 0.5rem;
+    cursor: pointer;
+    transition: box-shadow 0.15s ease;
+}
+
+.btn-cancel:hover {
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.25);
+    z-index: 40;
+}
+
+.modal-lg {
+    width: 100%;
+    min-height: 100vh;
+}
+
+.modal-md {
+    width: 87.5%; /* w-7/8 */
+    min-height: 80vh;
+}
+
+@media (min-width: 640px) {
+    .modal-md {
+        width: 75%; /* sm:w-3/4 */
+    }
+}
+
+.modal-sm {
+    width: 75%; /* w-3/4 */
+    min-height: 60vh;
+}
+
+@media (min-width: 640px) {
+    .modal-sm {
+        width: 33.333333%; /* sm:w-1/3 */
+    }
+}
+
+.spinner {
+    width: 2rem;
+    height: 2rem;
+    animation: spin 1s linear infinite;
+    color: #10b981;
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/src/lib/Modals/Grav_Modal.svelte
+++ b/src/lib/Modals/Grav_Modal.svelte
@@ -28,9 +28,9 @@
 
     // Size classes mapping
     const sizeClasses: Record<ModalSize, string> = {
-        lg: "w-full min-h-screen",
-        md: "sm:w-3/4 w-7/8 min-h-[80vh]",
-        sm: "sm:w-1/3 w-3/4 min-h-[60vh]",
+        lg: "modal-lg",
+        md: "modal-md",
+        sm: "modal-sm",
     };
 
     // Get the current size class
@@ -71,25 +71,25 @@
 
 <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 <div
-    class="overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none justify-center items-center flex"
+    class="modal"
     on:keydown={handleKeydown}
     on:click={handleClick}
     tabindex="0"
 >
     <!--content-->
     <div
-        class="border-0 shadow-lg relative flex flex-col {currentSizeClass} bg-white outline-none focus:outline-none"
+        class="modal-content {currentSizeClass}"
     >
         <!-- Encabezado Modal -->
         <div
-            class="flex items-start justify-between p-4 border-b border-solid border-blueGray-200 rounded-t"
+            class="modal-header"
         >
-            <h3 class="text-xl font-semibold">
+            <h3 class="modal-title">
                 {title}
             </h3>
             <!-- Cerrar Modal -->
             <button
-                class="p-1 cursor-pointer ml-auto bg-transparent border-0 text-black float-right text-2xl leading-none font-semibold outline-none focus:outline-none"
+                class="close-btn"
                 on:click={onClose}
             >
                 <svg
@@ -112,10 +112,10 @@
         <!-- Encabezado Modal -->
 
         {#if loading}
-            <div class="relative p-6 flex-1 flex justify-center items-center">
-                <div class="flex justify-center text-4xl items-center">
+            <div class="modal-body" style="display:flex; justify-content:center; align-items:center;">
+                <div>
                     <svg
-                        class="animate-spin h-8 w-8 text-emerald-500"
+                        class="spinner"
                         xmlns="http://www.w3.org/2000/svg"
                         fill="none"
                         viewBox="0 0 24 24"
@@ -138,19 +138,17 @@
             </div>
         {:else}
             <!-- Cuerpo Modal -->
-            <div class="relative sm:p-4 p-2 flex-auto">
+            <div class="modal-body">
                 <slot />
             </div>
             <!-- /Cuerpo Modal -->
 
             {#if !isVista}
                 <!-- Pie Modal -->
-                <div
-                    class="flex items-center justify-end p-3 border-t border-solid border-blueGray-200"
-                >
+                <div class="modal-footer">
                     <!-- Btn Guardar -->
                     <button
-                        class="bg-emerald-500 cursor-pointer disabled:bg-emerald-300 text-white active:bg-emerald-600 font-bold uppercase text-sm px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none ease-linear transition-all duration-150"
+                        class="btn-save"
                         type="button"
                         on:click={onSave}
                         disabled={saveButtonDisabled}
@@ -160,7 +158,7 @@
                     <!-- /Btn Guardar -->
                     <!-- Cerrar Modal -->
                     <button
-                        class=" disabled:bg-emerald-300 cursor-pointer text-red-500 font-bold uppercase text-sm px-6 py-3 rounded hover:shadow-lg outline-none focus:outline-none ease-linear transition-all duration-150"
+                        class="btn-cancel"
                         type="button"
                         on:click={onClose}
                     >
@@ -173,4 +171,4 @@
         {/if}
     </div>
 </div>
-<div class="opacity-25 fixed inset-0 z-40 bg-black" />
+<div class="overlay" />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,59 +3,57 @@
     import "../app.css";
 </script>
 
-<div class="min-h-screen bg-gray-100">
+<div class="layout-container">
     <!-- Navigation -->
-    <nav class="bg-white shadow-sm">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between h-16">
-                <div class="flex">
-                    <div class="flex-shrink-0 flex items-center">
-                        <a href="/" class="text-xl font-bold text-gray-800 hover:text-gray-600 transition-colors">
+    <nav class="navbar">
+        <div class="navbar-inner">
+            <div class="navbar-main">
+                <div class="brand-wrapper">
+                    <a href="/" class="navbar-brand">
                             Grav Svelte
                         </a>
-                    </div>
-                    <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
-                        <a
-                            href="/inputs"
-                            class="{$page.url.pathname === '/inputs' ? 'border-blue-500 text-gray-900' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'} inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
-                        >
-                            Inputs
-                        </a>
-                        <a
-                            href="/modales"
-                            class="{$page.url.pathname === '/modales' ? 'border-blue-500 text-gray-900' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'} inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
-                        >
-                            Modals
-                        </a>
-                        <a
-                            href="/crud"
-                            class="{$page.url.pathname === '/crud' ? 'border-blue-500 text-gray-900' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'} inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
-                        >
-                            CRUD
-                        </a>
-                    </div>
+                </div>
+                <div class="links-desktop">
+                    <a
+                        href="/inputs"
+                        class="nav-link" class:active={$page.url.pathname === '/inputs'}
+                    >
+                        Inputs
+                    </a>
+                    <a
+                        href="/modales"
+                        class="nav-link" class:active={$page.url.pathname === '/modales'}
+                    >
+                        Modals
+                    </a>
+                    <a
+                        href="/crud"
+                        class="nav-link" class:active={$page.url.pathname === '/crud'}
+                    >
+                        CRUD
+                    </a>
                 </div>
             </div>
         </div>
 
         <!-- Mobile menu -->
-        <div class="sm:hidden">
-            <div class="pt-2 pb-3 space-y-1">
+        <div class="mobile-menu">
+            <div>
                 <a
                     href="/inputs"
-                    class="{$page.url.pathname === '/inputs' ? 'bg-blue-50 border-blue-500 text-blue-700' : 'border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700'} block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
+                    class="mobile-link" class:active={$page.url.pathname === '/inputs'}
                 >
                     Inputs
                 </a>
                 <a
                     href="/modales"
-                    class="{$page.url.pathname === '/modales' ? 'bg-blue-50 border-blue-500 text-blue-700' : 'border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700'} block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
+                    class="mobile-link" class:active={$page.url.pathname === '/modales'}
                 >
                     Modals
                 </a>
                 <a
                     href="/crud"
-                    class="{$page.url.pathname === '/crud' ? 'bg-blue-50 border-blue-500 text-blue-700' : 'border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700'} block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
+                    class="mobile-link" class:active={$page.url.pathname === '/crud'}
                 >
                     CRUD
                 </a>


### PR DESCRIPTION
## Summary
- remove Tailwind import and add custom CSS classes in `app.css`
- update layout to use new CSS classes
- refactor modal component to use CSS classes instead of Tailwind utilities
- refine CSS to better match original Tailwind styles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68424469f7e883209cd21c2551c31b83