### PR TITLE
Add boolean type support to CRUD tables

### DIFF
--- a/src/lib/CRUD/CrudTable.svelte
+++ b/src/lib/CRUD/CrudTable.svelte
@@ -145,6 +145,24 @@
                                             {item[tableBodyItem.campo] ?? ""}
                                         </p>
                                     </td>
+                                {:else if tableBodyItem.tipo == "Bool"}
+                                    <td
+                                        class="table-cell {i == 0
+                                            ? 'sticky-cell'
+                                            : ''}"
+                                    >
+                                        <p
+                                            class="cell-content {tableBodyItem.biBold
+                                                ? 'bold'
+                                                : ''}"
+                                        >
+                                            {#if item[tableBodyItem.campo] === true}
+                                                <i class="fas fa-check"></i>
+                                            {:else}
+                                                -
+                                            {/if}
+                                        </p>
+                                    </td>
                                 {:else if tableBodyItem.tipo == "Buttons"}
                                     <CrudTableButtons
                                         id={item[tableBodyItem.campo]}

--- a/src/lib/CRUD/interfaces.ts
+++ b/src/lib/CRUD/interfaces.ts
@@ -8,7 +8,7 @@ export interface ButtonConfig {
 export interface TableHeader {
     titulo: string;
     biSort: boolean;
-    tipo: 'Text' | 'Number' | 'Buttons';
+    tipo: 'Text' | 'Number' | 'Buttons' | 'Bool';
     biBold: boolean;
     campo: string;
     buttonsConfig: ButtonConfig[] | null;

--- a/src/routes/crud/+page.svelte
+++ b/src/routes/crud/+page.svelte
@@ -77,6 +77,14 @@
             buttonsConfig: [],
         },
         {
+            titulo: "Activo",
+            biSort: false,
+            tipo: "Bool",
+            biBold: false,
+            campo: "biActivo",
+            buttonsConfig: [],
+        },
+        {
             titulo: "Acciones",
             biSort: false,
             tipo: "Buttons",
@@ -116,6 +124,7 @@
             inCantidadDias: number;
             txComentariosMes: string;
             nvStatus: string;
+            biActivo: boolean;
         }[];
         total: number;
         page: number;
@@ -146,6 +155,7 @@
                         inCantidadDias: 31,
                         txComentariosMes: "Primer mes del año",
                         nvStatus: "Activo",
+                        biActivo: true,
                     },
                     {
                         noMesA: 2,
@@ -156,6 +166,7 @@
                         inCantidadDias: 29,
                         txComentariosMes: "Mes bisiesto",
                         nvStatus: "Activo",
+                        biActivo: false,
                     },
                     {
                         noMesA: 3,
@@ -166,6 +177,7 @@
                         inCantidadDias: 31,
                         txComentariosMes: "Inicio de primavera",
                         nvStatus: "Activo",
+                        biActivo: true,
                     },
                 ],
                 total: 3,


### PR DESCRIPTION
## Summary
- allow `Bool` in table headers
- render check icon for boolean columns
- demonstrate bool column in CRUD example

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c35479ff08320b1fff0c14e062091