### PR TITLE
Add logout confirmation to sidebar

### DIFF
--- a/src/lib/Sidebar/SidebarWrapper.svelte
+++ b/src/lib/Sidebar/SidebarWrapper.svelte
@@ -2,6 +2,7 @@
     import type { SidebarSection } from "./sidebarConfig.js";
     import SidebarItem from "./SidebarItem.svelte";
     import "./SidebarWrapper.css";
+    import { Confirmacion_Alert } from "$lib/index.js";
     import { onMount } from 'svelte';
     // Props
     export let sections: SidebarSection[];
@@ -25,6 +26,17 @@
     function toggleCollapseShow() {
         console.log("toggleCollapseShow");
         collapseShow = !collapseShow;
+    }
+
+    function handleLogout(event: MouseEvent) {
+        event.preventDefault();
+        Confirmacion_Alert(
+            "Confirmar cierre de sesión",
+            "¿Desea cerrar sesión?",
+            () => {
+                window.location.href = logoutLink;
+            }
+        );
     }
 </script>
 
@@ -107,8 +119,13 @@
 
                     {#if showLogout}
                         <li class="logout-item">
-                            <a class="logout-link" href={logoutLink}>
-                                Log Out <i class="fas fa-sign-out-alt ml-2"></i>
+                            <a
+                                class="logout-link"
+                                href={logoutLink}
+                                on:click|preventDefault={handleLogout}
+                            >
+                                Log Out
+                                <i class="fas fa-sign-out-alt ml-2"></i>
                             </a>
                         </li>
                     {/if}


### PR DESCRIPTION
## Summary
- add confirmation alert to logout action in sidebar

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c356f5c9c83209a02248aa0087835