### PR TITLE
Add image support for CRUD tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Available components:
 - `FormBuilder` - Dynamic form generation
 - `Pagination` - Page navigation
 - `SearchInput` - Search with debounce
+- Image columns with URL support in data tables
 
 ## Documentation
 

--- a/src/lib/CRUD/CrudTable.svelte
+++ b/src/lib/CRUD/CrudTable.svelte
@@ -145,6 +145,18 @@
                                             {item[tableBodyItem.campo] ?? ""}
                                         </p>
                                     </td>
+                                {:else if tableBodyItem.tipo == "Image"}
+                                    <td
+                                        class="table-cell {i == 0
+                                            ? 'sticky-cell'
+                                            : ''}"
+                                    >
+                                        <img
+                                            class="crud-image"
+                                            src={item[tableBodyItem.campo] ?? ''}
+                                            alt="image"
+                                        />
+                                    </td>
                                 {:else if tableBodyItem.tipo == "Buttons"}
                                     <CrudTableButtons
                                         id={item[tableBodyItem.campo]}
@@ -346,5 +358,12 @@
         .cell-content {
             font-size: 1rem;
         }
+    }
+
+    .crud-image {
+        max-width: 4rem;
+        max-height: 4rem;
+        object-fit: contain;
+        margin: auto;
     }
 </style>

--- a/src/lib/CRUD/interfaces.ts
+++ b/src/lib/CRUD/interfaces.ts
@@ -8,7 +8,14 @@ export interface ButtonConfig {
 export interface TableHeader {
     titulo: string;
     biSort: boolean;
-    tipo: 'Text' | 'Number' | 'Buttons';
+    /**
+     * Tipo de dato de la columna.
+     * - `Text` Texto simple
+     * - `Number` Números
+     * - `Buttons` Grupo de botones de acción
+     * - `Image` URL de imagen a mostrar
+     */
+    tipo: 'Text' | 'Number' | 'Buttons' | 'Image';
     biBold: boolean;
     campo: string;
     buttonsConfig: ButtonConfig[] | null;

--- a/src/routes/crud/+page.svelte
+++ b/src/routes/crud/+page.svelte
@@ -77,6 +77,14 @@
             buttonsConfig: [],
         },
         {
+            titulo: "Imagen",
+            biSort: false,
+            tipo: "Image",
+            biBold: false,
+            campo: "image",
+            buttonsConfig: [],
+        },
+        {
             titulo: "Acciones",
             biSort: false,
             tipo: "Buttons",
@@ -116,6 +124,7 @@
             inCantidadDias: number;
             txComentariosMes: string;
             nvStatus: string;
+            image: string;
         }[];
         total: number;
         page: number;
@@ -146,6 +155,7 @@
                         inCantidadDias: 31,
                         txComentariosMes: "Primer mes del año",
                         nvStatus: "Activo",
+                        image: "https://via.placeholder.com/50",
                     },
                     {
                         noMesA: 2,
@@ -156,6 +166,7 @@
                         inCantidadDias: 29,
                         txComentariosMes: "Mes bisiesto",
                         nvStatus: "Activo",
+                        image: "https://via.placeholder.com/50",
                     },
                     {
                         noMesA: 3,
@@ -166,6 +177,7 @@
                         inCantidadDias: 31,
                         txComentariosMes: "Inicio de primavera",
                         nvStatus: "Activo",
+                        image: "https://via.placeholder.com/50",
                     },
                 ],
                 total: 3,


### PR DESCRIPTION
## Summary
- allow `Image` type in table headers
- render image cells in `CrudTable`
- demo usage on CRUD route
- mention image column support in README

## Testing
- `npm run check` *(fails: `svelte-kit: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c35ba89888320ad5924f547da6e0d