### PR TITLE
Add async select options for CRUD filters

### DIFF
--- a/src/lib/CRUD/CrudFilters.css
+++ b/src/lib/CRUD/CrudFilters.css
@@ -177,4 +177,25 @@
 
 .filter-item-bool {
     margin: auto 0;
+}
+
+.loading-spinner {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 38px;
+}
+
+.spinner {
+    width: 20px;
+    height: 20px;
+    border: 2px solid #f3f3f3;
+    border-top: 2px solid #3498db;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
 } 

--- a/src/lib/CRUD/CrudFilters.svelte
+++ b/src/lib/CRUD/CrudFilters.svelte
@@ -289,7 +289,7 @@
             class="filters-grid"
             transition:slide|local={{ duration: 300, delay: 100 }}
         >
-            {#each Filtros as { tipo, label, options }, i}
+            {#each Filtros as { tipo, label, options, service }, i}
                 {#if tipo == "text"}
                     <div class="filter-item">
                         <InputFormText
@@ -320,11 +320,25 @@
                     </div>
                 {:else if tipo == "select"}
                     <div class="filter-item filter-item-select">
-                        <InputFormSelect
-                            {label}
-                            res={options}
-                            bind:justValue={Filtros[i].value}
-                        />
+                        {#if service}
+                            {#await service() then asyncOptions}
+                                <InputFormSelect
+                                    {label}
+                                    res={asyncOptions}
+                                    bind:justValue={Filtros[i].value}
+                                />
+                            {:catch err}
+                                <span>Error loading options</span>
+                            {:pending}
+                                <span>Loading...</span>
+                            {/await}
+                        {:else}
+                            <InputFormSelect
+                                {label}
+                                res={options}
+                                bind:justValue={Filtros[i].value}
+                            />
+                        {/if}
                     </div>
                 {:else if tipo == "bool"}
                     <div class="filter-item filter-item-bool">

--- a/src/lib/CRUD/interfaces.ts
+++ b/src/lib/CRUD/interfaces.ts
@@ -18,7 +18,8 @@ export interface FiltrosI {
     tipo: 'number' | 'text' | 'date' | 'datetime' | 'select' | 'bool';
     label: string;
     value: any;
-    options: { value: any; label: string }[];
+    options?: { value: any; label: string }[];
+    service?: () => Promise<{ value: any; label: string }[]>;
 };
 
 export interface CrudWrapperProps {

--- a/src/routes/crud/+page.svelte
+++ b/src/routes/crud/+page.svelte
@@ -7,8 +7,16 @@
         {
             label: "Mes",
             value: "",
-            tipo: "text",
+            tipo: "select",
             options: [],
+            service: async () => {
+                await new Promise((res) => setTimeout(res, 500));
+                return [
+                    { value: "01", label: "Enero" },
+                    { value: "02", label: "Febrero" },
+                    { value: "03", label: "Marzo" },
+                ];
+            },
         },
     ];
 

--- a/src/routes/crud/+page.svelte
+++ b/src/routes/crud/+page.svelte
@@ -9,16 +9,36 @@
             value: "",
             tipo: "select",
             options: [],
-            service: async () => {
-                await new Promise((res) => setTimeout(res, 500));
-                return [
-                    { value: "01", label: "Enero" },
-                    { value: "02", label: "Febrero" },
-                    { value: "03", label: "Marzo" },
-                ];
-            },
+            service: fakeService,
+        },
+        {
+            label: "Mes sin service",
+            value: "",
+            tipo: "select",
+            options: [
+                { value: "01", label: "Enero" },
+                { value: "02", label: "Febrero" },
+                { value: "03", label: "Marzo" },
+            ],
         },
     ];
+
+    async function fakeService() {
+        await new Promise((res) => setTimeout(res, 500));
+        console.log("fakeService");
+        return [
+            { value: "01", label: "Enero" },
+            { value: "02", label: "Febrero" },
+            { value: "03", label: "Marzo" },
+            { value: "04", label: "Abril" },
+            { value: "05", label: "Mayo" },
+            { value: "06", label: "Junio" },
+            { value: "07", label: "Julio" },
+            { value: "08", label: "Agosto" },
+            { value: "09", label: "Septiembre" },
+            { value: "10", label: "Octubre" },
+        ];
+    }
 
     let todosLosObjetos: any[] = [];
     let totalRows = 0;
@@ -221,22 +241,22 @@
 </svelte:head>
 
 <div class="min-h-screen p-4 bg-white">
-<CrudWrapper
-    Titulo_Crud="Catálogo Meses"
-    {todosLosObjetos}
-    {tableH}
-    {totalRows}
-    bind:Filtros
-    bind:PageSize
-    bind:currentPage
-    bind:selectedAscOrDesc
-    bind:selectedSort
-    {loading}
-    showAddButton={true}
-    showImportButton={false}
-    onFilter={enlistar}
-    onAdd={handleAdd}
-/>
+    <CrudWrapper
+        Titulo_Crud="Catálogo Meses"
+        {todosLosObjetos}
+        {tableH}
+        {totalRows}
+        bind:Filtros
+        bind:PageSize
+        bind:currentPage
+        bind:selectedAscOrDesc
+        bind:selectedSort
+        {loading}
+        showAddButton={true}
+        showImportButton={false}
+        onFilter={enlistar}
+        onAdd={handleAdd}
+    />
     <div class="bg-white p-6 rounded-lg shadow-md mt-6">
         <div class="flex justify-between items-center mb-4">
             <h2 class="text-xl font-semibold">Code Preview</h2>
@@ -249,6 +269,9 @@
                 Copy Code
             </button>
         </div>
-        <pre class="bg-gray-800 text-gray-100 p-4 rounded-md overflow-x-auto text-sm"><code>{codePreview}</code></pre>
+        <pre
+            class="bg-gray-800 text-gray-100 p-4 rounded-md overflow-x-auto text-sm"><code
+                >{codePreview}</code
+            ></pre>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- allow CRUD filters to fetch select options with a service function
- render async select options in CrudFilters using a `{#await}` block
- demonstrate usage with a service in example CRUD page

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3771dfe483208c44cc997969b0cc