### PR TITLE
Fix hover bg color for sticky column

### DIFF
--- a/src/lib/CRUD/CrudTable.svelte
+++ b/src/lib/CRUD/CrudTable.svelte
@@ -275,7 +275,17 @@
         background-color: #f5f5f5;
     }
 
+    /* ensure sticky cells follow row hover */
+    .table-row:hover .sticky-cell {
+        background-color: #f5f5f5;
+    }
+
     .table-row.selected {
+        background-color: #e8e8e8;
+    }
+
+    /* keep first column selected state consistent */
+    .table-row.selected .sticky-cell {
         background-color: #e8e8e8;
     }
 


### PR DESCRIPTION
## Summary
- ensure first column inherits row hover/selected backgrounds

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c391334ec8320b2194888f447eeca