### PR TITLE
Reset sort when clearing filters

### DIFF
--- a/src/lib/CRUD/CrudFilters.svelte
+++ b/src/lib/CRUD/CrudFilters.svelte
@@ -42,6 +42,10 @@
             value: filtro.tipo === "bool" ? false : "",
         }));
         console.log(Filtros);
+
+        // Inform parent components that filters were cleared so other
+        // states like sorting can be reset as well
+        dispatch("clearFilters");
         dispatch("filtrar", { filtros: Filtros }); // puedes pasar los filtros actualizados
     }
 

--- a/src/lib/CRUD/CrudWrapper.svelte
+++ b/src/lib/CRUD/CrudWrapper.svelte
@@ -54,6 +54,12 @@
         onFilter(Filtros);
     }
 
+    function handleClearFilters() {
+        // Reset sorting when filters are cleared
+        selectedSort = "";
+        selectedAscOrDesc = "asc";
+    }
+
     function handleExport(type: "excel" | "pdf") {
         const table = document.querySelector("table");
         if (!table) return;
@@ -71,6 +77,7 @@
         bind:PageSize
         bind:Filtros
         on:filtrar={handleFiltroAplicado}
+        on:clearFilters={handleClearFilters}
         on:add={handleAdd}
         {showAddButton}
         {showImportButton}


### PR DESCRIPTION
## Summary
- dispatch `clearFilters` event from `CrudFilters`
- listen to `clearFilters` in `CrudWrapper` to reset sort values

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c398ab0948320b5f164f82d8491d1