### PR TITLE
Add image modal for CRUD table

### DIFF
--- a/src/lib/CRUD/CrudTable.svelte
+++ b/src/lib/CRUD/CrudTable.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-    import CrudTableButtons from "./CrudTableButtons.svelte";
+import CrudTableButtons from "./CrudTableButtons.svelte";
+import { openModal, closeModal } from "$lib/Modals/index.js";
+import ImageModal from "./ImageModal.svelte";
 
     // COMPONENTES imports
 
@@ -35,6 +37,11 @@
             selectedSort: selection,
             selectedAsc: selectedAscOrDesc,
         });
+    }
+
+    function openImageModal(src: string) {
+        closeModal("crud-image-modal");
+        openModal("crud-image-modal", ImageModal, { src });
     }
 </script>
 
@@ -175,10 +182,10 @@
                                             : ''}"
                                     >
                                         <img
-                                            class="crud-image"
-                                            src={item[tableBodyItem.campo] ??
-                                                ""}
+                                            class="crud-image cursor-pointer"
+                                            src={item[tableBodyItem.campo] ?? ''}
                                             alt="image"
+                                            on:click={() => openImageModal(item[tableBodyItem.campo])}
                                         />
                                     </td>
                                 {:else if tableBodyItem.tipo == "Buttons"}

--- a/src/lib/CRUD/CrudWrapper.svelte
+++ b/src/lib/CRUD/CrudWrapper.svelte
@@ -3,7 +3,8 @@
     import CrudFilters from "./CrudFilters.svelte";
     import CrudTable from "./CrudTable.svelte";
     import type { FiltrosI, TableHeader, CrudWrapperProps } from "./interfaces.js";
-    import PaginationCrud from "./PaginationCRUD.svelte";
+import PaginationCrud from "./PaginationCRUD.svelte";
+import { ModalContainer } from "$lib/Modals/index.js";
 
     export let Filtros: FiltrosI[];
     export let todosLosObjetos: any[];
@@ -105,6 +106,7 @@
             <i class="far fa-file-pdf pr-3"> </i>PDF
         </button>
     </div>
+    <ModalContainer />
 </div>
 
 <style>

--- a/src/lib/CRUD/ImageModal.svelte
+++ b/src/lib/CRUD/ImageModal.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import { Grav_Modal, closeModal } from '$lib/Modals/index.js';
+    export let src: string;
+    const MODAL_ID = 'crud-image-modal';
+</script>
+
+<Grav_Modal
+    title="Imagen"
+    size="md"
+    isVista={true}
+    onClose={() => closeModal(MODAL_ID)}
+>
+    <div class="flex items-center justify-center p-4">
+        <img src={src} alt="image" class="max-w-full max-h-[80vh]" />
+    </div>
+</Grav_Modal>

--- a/src/lib/CRUD/index.ts
+++ b/src/lib/CRUD/index.ts
@@ -3,6 +3,7 @@ export { default as CrudTable } from './CrudTable.svelte';
 export { default as CrudFilters } from './CrudFilters.svelte';
 export { default as PaginationCrud } from './PaginationCRUD.svelte';
 export { default as CrudTableButtons } from './CrudTableButtons.svelte';
+export { default as ImageModal } from './ImageModal.svelte';
 
 export type { 
     ButtonConfig, 


### PR DESCRIPTION
## Summary
- show modal container in `CrudWrapper`
- support viewing images in a modal from CRUD tables
- export new `ImageModal` component

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c613d03f0832087c236edf698054f