### PR TITLE
Fix tooltips covering CRUD buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "grav-svelte",
-	"version": "0.0.33",
+	"version": "0.0.34",
 	"description": "A collection of Svelte components",
 	"license": "MIT",
 	"scripts": {

--- a/src/lib/CRUD/CrudFilters.css
+++ b/src/lib/CRUD/CrudFilters.css
@@ -74,6 +74,7 @@
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
     top: -1.25rem;
     left: -2.5rem;
+    pointer-events: none;
 }
 
 .action-button {

--- a/src/lib/CRUD/CrudTableButtons.svelte
+++ b/src/lib/CRUD/CrudTableButtons.svelte
@@ -58,6 +58,7 @@
         box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
         top: -1.5rem;
         right: -2.5rem;
+        pointer-events: none;
     }
 
     .action-buttons-group {


### PR DESCRIPTION
## Summary
- avoid pointer events on tooltips so buttons remain clickable

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685036d2db2483209f00296b1334c84d