### PR TITLE
Add spacing to export buttons

### DIFF
--- a/src/lib/CRUD/CrudWrapper.svelte
+++ b/src/lib/CRUD/CrudWrapper.svelte
@@ -96,14 +96,14 @@ import { ModalContainer } from "$lib/Modals/index.js";
             on:click={() => handleExport("excel")}
             class="export-button excel-button"
         >
-            <i class="fas fa-file-excel pr-3"> </i>EXCEL
+            <i class="fas fa-file-excel"></i>EXCEL
         </button>
         <button
             type="button"
             on:click={() => handleExport("pdf")}
             class="export-button pdf-button"
         >
-            <i class="far fa-file-pdf pr-3"> </i>PDF
+            <i class="far fa-file-pdf"></i>PDF
         </button>
     </div>
     <ModalContainer />
@@ -127,6 +127,10 @@ import { ModalContainer } from "$lib/Modals/index.js";
         color: white;
         padding: 1rem;
         border-radius: 0.25rem;
+    }
+
+    .export-button i {
+        margin-right: 0.75rem;
     }
 
     .excel-button {


### PR DESCRIPTION
## Summary
- tweak Excel and PDF export buttons
- space icon away from text using CSS

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5369290083208e23ef06371eb4c2