### PR TITLE
Add visibility flag to CRUD buttons

### DIFF
--- a/src/lib/CRUD/CrudTableButtons.svelte
+++ b/src/lib/CRUD/CrudTableButtons.svelte
@@ -5,11 +5,13 @@
     export let buttonsConfig: ButtonConfig[];
     export let align: 'left' | 'right' | 'center' = 'center';
     let showTooltip = "";
+
+    $: visibleButtons = buttonsConfig.filter((btn) => btn.show ?? true);
 </script>
 
 <td class="table-cell" style="text-align: {align}">
     <div class="button-group" role="group">
-        {#each buttonsConfig as button, i}
+        {#each visibleButtons as button, i}
             <div class="tooltip-container">
                 {#if showTooltip == button.tooltip}
                     <div class="tooltip">
@@ -23,7 +25,7 @@
                 on:mouseenter={() => (showTooltip = button.tooltip)}
                 on:mouseleave={() => (showTooltip = "")}
                 type="button"
-                class="action-buttons-group {i == 0 ? 'rounded-left' : i == buttonsConfig.length - 1 ? 'rounded-right' : ''} {button.color}"
+                class="action-buttons-group {i == 0 ? 'rounded-left' : i == visibleButtons.length - 1 ? 'rounded-right' : ''} {button.color}"
             >
                 <i class={button.icon}> </i>
             </button>

--- a/src/lib/CRUD/interfaces.ts
+++ b/src/lib/CRUD/interfaces.ts
@@ -3,6 +3,10 @@ export interface ButtonConfig {
     color: string;
     action: (id: number) => void;
     tooltip: string;
+    /**
+     * When set to false the button will not be rendered. Defaults to true.
+     */
+    show?: boolean;
 }
 
 export interface TableHeader {

--- a/src/routes/crud/+page.svelte
+++ b/src/routes/crud/+page.svelte
@@ -140,6 +140,7 @@
                     icon: "fa-solid fa-pencil",
                     tooltip: "Editar",
                     color: "bg-yellow-500 hover:bg-yellow-700",
+                    show: true,
                     action: (id: number) => {
                         alert("Editar");
                     },
@@ -148,6 +149,7 @@
                     icon: "fa-solid fa-trash",
                     tooltip: "Eliminar",
                     color: "bg-red-500 hover:bg-red-700",
+                    show: true,
                     action: (id: number) => {
                         alert("Eliminar");
                     },


### PR DESCRIPTION
## Summary
- add optional `show` flag to ButtonConfig
- hide buttons in `<CrudTableButtons>` when `show` is false
- demonstrate `show` flag usage in example CRUD page

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f443c7ea883208faf11ab0b837b4c